### PR TITLE
Fix multiple async refresh call for same value

### DIFF
--- a/src/main/kotlin/pl/tfij/brightcache/CacheEventHandler.kt
+++ b/src/main/kotlin/pl/tfij/brightcache/CacheEventHandler.kt
@@ -8,76 +8,57 @@ interface CacheEventHandler<K, V> {
      * The method is called when the value for a given key is stored in the L1 cache. The value will be return from
      * L1 cache.
      */
-    fun handleL1Hit(key: K)
+    fun onL1HitOccurred(key: K) {}
 
     /**
      * The method is called when the value for a given key is not stored in the L1 cache. After invoking it, BrightCache
      * will try to get value from L2 cache.
      */
-    fun handleL1Miss(key: K)
+    fun onL1MissOccurred(key: K) {}
 
     /**
      * The method is called when the value for a given key is stored in the L2 cache. After invoking it, BrightCache
      * will try to asynchronously reload the value into the L2 cache.
      */
-    fun handleL2Hit(key: K)
+    fun onL2HitOccurred(key: K) {}
 
     /**
      * The method is called when the value for a given key is not stored in the L2 cache. After invoking it, BrightCache
      * will try to synchronously load the value into the L2 cache.
      */
-    fun handleL2Miss(key: K)
+    fun onL2MissOccurred(key: K) {}
 
     /**
      * The method is called when an error occurs on the loading value in the async process. The BrightCache can provide
      * value for such a key till the L2 TTL not exceeded.
      */
-    fun handleAsyncValueLoaderError(key: K, ex: Exception)
+    fun onAsyncValueLoaderErrorOccurred(key: K, ex: Exception) {}
 
     /**
      * The method is called when value is successfully loaded and stored in the cache.
      */
-    fun handleValueLoaderSucceed(key: K, loadedValue: V)
+    fun onValueLoaderSucceedOccurred(key: K, loadedValue: V) {}
 
     /**
      * The method is called when an error occurs on the loading value after the retry counter is exceeded.
      */
-    fun handleValueLoaderError(key: K, ex: Exception)
+    fun onValueLoaderErrorOccurred(key: K, ex: Exception) {}
 
     /**
      * The method is called when an exception is thrown on retry. The exception will be caught and BrighrCache repeats
      * the retry until getting a successful result or to retry counter is exceeded.
      */
-    fun handleRetryError(tryNumber: Int, ex: Exception)
+    fun onRetryErrorOccurred(tryNumber: Int, ex: Exception) {}
+
+    /**
+     * This method is called when async refresh is skipped due to other call already start refresh for the key
+     */
+    fun onAsyncValueSkippedOccurred(key: K) {}
+
+    /**
+     * This method is called when async refresh for the key is triggered
+     */
+    fun onAsyncValueLoaderTriggeredOccurred(key: K) {}
 }
 
-class DummyCacheEventHandler<K, V> : CacheEventHandler<K, V> {
-    override fun handleL1Hit(key: K) {}
-
-    override fun handleL1Miss(key: K) {}
-
-    override fun handleL2Hit(key: K) {
-        TODO("Not yet implemented")
-    }
-
-    override fun handleL2Miss(key: K) {
-        TODO("Not yet implemented")
-    }
-
-    override fun handleAsyncValueLoaderError(key: K, ex: Exception) {
-        TODO("Not yet implemented")
-    }
-
-    override fun handleValueLoaderSucceed(key: K, loadedValue: V) {
-        TODO("Not yet implemented")
-    }
-
-    override fun handleValueLoaderError(key: K, ex: Exception) {
-        TODO("Not yet implemented")
-    }
-
-    override fun handleRetryError(tryNumber: Int, ex: Exception) {
-        TODO("Not yet implemented")
-    }
-
-}
+class DummyCacheEventHandler<K, V> : CacheEventHandler<K, V>

--- a/src/test/groovy/pl/tfij/brightcache/BrightCacheAsyncRefreshSpec.groovy
+++ b/src/test/groovy/pl/tfij/brightcache/BrightCacheAsyncRefreshSpec.groovy
@@ -1,0 +1,59 @@
+package pl.tfij.brightcache
+
+import com.google.common.cache.Cache
+import pl.tfij.brightcache.fixture.TestCacheEventHandler
+import pl.tfij.brightcache.fixture.ThreadSafeSlowUserProviderWithCount
+import pl.tfij.brightcache.fixture.User
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+import static pl.tfij.brightcache.fixture.SampleBrightCacheFactory.sampleL1Cache
+import static pl.tfij.brightcache.fixture.SampleBrightCacheFactory.sampleL2Cache
+
+class BrightCacheAsyncRefreshSpec extends Specification {
+
+    def "Should call once async refresh function if many calls try to get value for the key at same time and value in L1 expired 2"() {
+        given: "configured BrightCache with a thread pool"
+        Cache<String, User> l1Cache = sampleL1Cache()
+        Cache<String, User> l2Cache = sampleL2Cache()
+        ExecutorService cacheRefreshExecutor = Executors.newFixedThreadPool(10)
+        TestCacheEventHandler handler = new TestCacheEventHandler()
+        BrightCache<String, User> cache = new BrightCache<>(l1Cache, l2Cache, cacheRefreshExecutor, handler)
+
+        and: "slow user provider provider with counter"
+        String firstUserId = "sampleUserId-1"
+        ThreadSafeSlowUserProviderWithCount firstUserProvider = new ThreadSafeSlowUserProviderWithCount(firstUserId)
+
+        and: "another slow user provider provider with counter"
+        String secondUserId = "sampleUserId-2"
+        ThreadSafeSlowUserProviderWithCount secondUserProvider = new ThreadSafeSlowUserProviderWithCount(secondUserId)
+
+        and: "users are in cache L1 but not in L2"
+        cache.get(firstUserId, {new User("initUserId-1", "initUserName-1") } )
+        cache.get(secondUserId, {new User("initUserId-2", "initUserName-2") } )
+        l1Cache.invalidateAll()
+
+        when: "I get value two times for first user"
+        cache.get(firstUserId, { firstUserProvider.getUser() } )
+        cache.get(firstUserId, { firstUserProvider.getUser() } )
+
+        and: "I get value once for second user"
+        cache.get(secondUserId, { secondUserProvider.getUser() } )
+
+        and: "wait until all async calls occurred"
+        new PollingConditions().within(1) { handler.asyncValueSkippedCounter() == 1 }
+        new PollingConditions().within(1) { handler.asyncValueLoaderTriggeredCounter() == 2 }
+
+        and: "userProviders finished"
+        firstUserProvider.markAsReady()
+        secondUserProvider.markAsReady()
+
+        then: "async function was call once for each user"
+        firstUserProvider.counter == 1
+        secondUserProvider.counter == 1
+    }
+
+}

--- a/src/test/groovy/pl/tfij/brightcache/BrightCacheSpec.groovy
+++ b/src/test/groovy/pl/tfij/brightcache/BrightCacheSpec.groovy
@@ -1,7 +1,6 @@
 package pl.tfij.brightcache
 
 import com.google.common.cache.Cache
-import com.google.common.cache.CacheBuilder
 import pl.tfij.brightcache.fixture.DummyUserProviderWithCount
 import pl.tfij.brightcache.fixture.SelfThreadExecutorService
 import pl.tfij.brightcache.fixture.TestCacheEventHandler
@@ -9,7 +8,9 @@ import pl.tfij.brightcache.fixture.User
 import spock.lang.Specification
 
 import java.util.concurrent.ExecutorService
-import java.util.concurrent.TimeUnit
+
+import static pl.tfij.brightcache.fixture.SampleBrightCacheFactory.sampleL1Cache
+import static pl.tfij.brightcache.fixture.SampleBrightCacheFactory.sampleL2Cache
 
 class BrightCacheSpec extends Specification {
 
@@ -102,20 +103,6 @@ class BrightCacheSpec extends Specification {
         Cache<String, User> l2Cache = sampleL2Cache()
         ExecutorService cacheRefreshExecutor = sampleExecutorService()
         return new BrightCache<>(l1Cache, l2Cache, cacheRefreshExecutor, handler)
-    }
-
-    private static Cache<String, User> sampleL1Cache() {
-        return CacheBuilder.newBuilder()
-                .maximumSize(10)
-                .expireAfterWrite(30, TimeUnit.MINUTES)
-                .build()
-    }
-
-    private static Cache<String, User> sampleL2Cache() {
-        return CacheBuilder.newBuilder()
-                .maximumSize(10)
-                .expireAfterWrite(24, TimeUnit.HOURS)
-                .build()
     }
 
     private static ExecutorService sampleExecutorService() {

--- a/src/test/groovy/pl/tfij/brightcache/fixture/SampleBrightCacheFactory.groovy
+++ b/src/test/groovy/pl/tfij/brightcache/fixture/SampleBrightCacheFactory.groovy
@@ -1,0 +1,24 @@
+package pl.tfij.brightcache.fixture
+
+import com.google.common.cache.Cache
+import com.google.common.cache.CacheBuilder
+import groovy.transform.CompileStatic
+
+import java.util.concurrent.TimeUnit
+
+@CompileStatic
+class SampleBrightCacheFactory {
+    static Cache<String, User> sampleL1Cache() {
+        return CacheBuilder.newBuilder()
+                .maximumSize(10)
+                .expireAfterWrite(30, TimeUnit.MINUTES)
+                .build()
+    }
+
+    static Cache<String, User> sampleL2Cache() {
+        return CacheBuilder.newBuilder()
+                .maximumSize(10)
+                .expireAfterWrite(24, TimeUnit.HOURS)
+                .build()
+    }
+}

--- a/src/test/groovy/pl/tfij/brightcache/fixture/TestCacheEventHandler.groovy
+++ b/src/test/groovy/pl/tfij/brightcache/fixture/TestCacheEventHandler.groovy
@@ -1,7 +1,6 @@
 package pl.tfij.brightcache.fixture
 
 import groovy.transform.CompileStatic
-import org.jetbrains.annotations.NotNull
 import pl.tfij.brightcache.CacheEventHandler
 
 @CompileStatic
@@ -9,43 +8,53 @@ class TestCacheEventHandler implements CacheEventHandler {
     private final Map<String, Integer> counters = new HashMap<>()
 
     @Override
-    void handleL1Hit(Object key) {
+    void onL1HitOccurred(Object key) {
         increaseCounter("l1Hit")
     }
 
     @Override
-    void handleL1Miss(Object key) {
+    void onL1MissOccurred(Object key) {
         increaseCounter("l1Miss")
     }
 
     @Override
-    void handleL2Hit(Object key) {
+    void onL2HitOccurred(Object key) {
         increaseCounter("l2Hit")
     }
 
     @Override
-    void handleL2Miss(Object key) {
+    void onL2MissOccurred(Object key) {
         increaseCounter("l2Hit")
     }
 
     @Override
-    void handleAsyncValueLoaderError(Object key, @NotNull Exception ex) {
+    void onAsyncValueLoaderErrorOccurred(Object key, Exception ex) {
         increaseCounter("asyncValueLoaderError")
     }
 
     @Override
-    void handleValueLoaderSucceed(Object key, Object loadedValue) {
+    void onValueLoaderSucceedOccurred(Object key, Object loadedValue) {
         increaseCounter("valueLoaderSucceed")
     }
 
     @Override
-    void handleValueLoaderError(Object key, @NotNull Exception ex) {
+    void onValueLoaderErrorOccurred(Object key, Exception ex) {
         increaseCounter("valueLoaderError")
     }
 
     @Override
-    void handleRetryError(int tryNumber, @NotNull Exception ex) {
+    void onRetryErrorOccurred(int tryNumber, Exception ex) {
         increaseCounter("retryError")
+    }
+
+    @Override
+    void onAsyncValueSkippedOccurred(Object key) {
+        increaseCounter("asyncValueSkip")
+    }
+
+    @Override
+    void onAsyncValueLoaderTriggeredOccurred(Object key) {
+        increaseCounter("asyncValueLoaderTriggered")
     }
 
     private void increaseCounter(String key) {
@@ -71,5 +80,13 @@ class TestCacheEventHandler implements CacheEventHandler {
 
     int l2MissCounter() {
         return counters["l2Miss"] ?: 0
+    }
+
+    int asyncValueSkippedCounter() {
+        return  counters["asyncValueSkip"] ?: 0
+    }
+
+    int asyncValueLoaderTriggeredCounter() {
+        return  counters["asyncValueLoaderTriggered"] ?: 0
     }
 }

--- a/src/test/groovy/pl/tfij/brightcache/fixture/ThreadSafeSlowUserProviderWithCount.groovy
+++ b/src/test/groovy/pl/tfij/brightcache/fixture/ThreadSafeSlowUserProviderWithCount.groovy
@@ -1,0 +1,34 @@
+package pl.tfij.brightcache.fixture
+
+import groovy.transform.CompileStatic
+
+import java.util.concurrent.atomic.AtomicInteger
+
+@CompileStatic
+class ThreadSafeSlowUserProviderWithCount {
+    private AtomicInteger counter = new AtomicInteger(0)
+    private final String id;
+    private volatile boolean isReady = false
+
+    ThreadSafeSlowUserProviderWithCount(String id) {
+        this.id = id
+    }
+
+    User getUser() {
+        counter.incrementAndGet()
+        while (true) {
+            if (isReady) {
+                break
+            }
+        }
+        return new User(id, "sampleFirstName${UUID.randomUUID().toString()}")
+    }
+
+    void markAsReady() {
+        isReady = true
+    }
+
+    int getCounter() {
+        return counter.intValue()
+    }
+}


### PR DESCRIPTION
BUG DESCRIPTION: If many calls for the same key appear before the value
is calculated, then the same calculation is triggered for each call.